### PR TITLE
Enable Ruff for linting and clean up Python imports

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,15 @@
+{
+    "python.linting.enabled": true,
+    "python.linting.ruffEnabled": true,
+    "python.linting.pylintEnabled": false,
+    "python.linting.flake8Enabled": false,
+    "python.linting.mypyEnabled": false,
+    "python.linting.pycodestyleEnabled": false,
+    "python.formatting.provider": "none",
+    "python.formatting.provider": "ruff",
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+        "source.fixAll.ruff": true,
+        "source.organizeImports": true
+    }
+}

--- a/adb_utils.py
+++ b/adb_utils.py
@@ -1,11 +1,14 @@
-import subprocess
-import cv2
 import os
+import subprocess
 import time
 from threading import Thread
 
+import cv2
+
+
 def connect_to_emulator(emulator_name):
     subprocess.run(["adb", "connect", emulator_name])
+
 
 def take_screenshot():
     screenshot_path = os.path.join("images", "screenshot.png")
@@ -13,13 +16,16 @@ def take_screenshot():
     subprocess.run(["adb", "pull", "/sdcard/screenshot.png", screenshot_path])
     return cv2.imread(screenshot_path)
 
+
 def click_position(x, y):
-    subprocess.run(['adb', 'shell', 'input', 'tap', str(x), str(y)])
+    subprocess.run(["adb", "shell", "input", "tap", str(x), str(y)])
+
 
 def find_subimage(screenshot, subimage):
     result = cv2.matchTemplate(screenshot, subimage, cv2.TM_CCOEFF_NORMED)
     _, max_val, _, max_loc = cv2.minMaxLoc(result)
     return max_loc, max_val
+
 
 def long_press_position(x, y, duration=1.0):
     screenshot = None
@@ -33,22 +39,40 @@ def long_press_position(x, y, duration=1.0):
     screenshot_thread.start()
 
     subprocess.run(
-        ["adb", "shell", "input", "swipe", str(x), str(y), str(x), str(y), str(int(duration * 1000))]
+        [
+            "adb",
+            "shell",
+            "input",
+            "swipe",
+            str(x),
+            str(y),
+            str(x),
+            str(y),
+            str(int(duration * 1000)),
+        ]
     )
 
     screenshot_thread.join()
 
     return screenshot
 
+
 def drag_position(start_pos, end_pos, duration=0.5):
     start_x, start_y = start_pos
     end_x, end_y = end_pos
-    
+
     duration_ms = int(duration * 500)
-    
-    subprocess.run([
-        "adb", "shell", "input", "swipe",
-        str(start_x), str(start_y),
-        str(end_x), str(end_y),
-        str(duration_ms)
-    ])
+
+    subprocess.run(
+        [
+            "adb",
+            "shell",
+            "input",
+            "swipe",
+            str(start_x),
+            str(start_y),
+            str(end_x),
+            str(end_y),
+            str(duration_ms),
+        ]
+    )

--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
 import tkinter as tk
-from ui import BotUI
+
 from app_state import AppState
+from ui import BotUI
 
 if __name__ == "__main__":
     root = tk.Tk()

--- a/battle_actions.py
+++ b/battle_actions.py
@@ -1,6 +1,7 @@
-import time
 import os
-from adb_utils import long_press_position, find_subimage, take_screenshot
+import time
+
+from adb_utils import find_subimage, long_press_position, take_screenshot
 
 
 class BattleActions:
@@ -45,7 +46,7 @@ class BattleActions:
     def perform_search_battle_actions(self, running, stop, run_event=False):
         if not self.image_processor.check_and_click_until_found(
             self.template_images["VERSUS_SCREEN"],
-            'Versus Screen',
+            "Versus Screen",
             running,
             stop,
             max_attempts=10,
@@ -54,14 +55,14 @@ class BattleActions:
         if run_event:
             if not self.image_processor.check_and_click_until_found(
                 self.template_images["EVENT_MATCH_SCREEN"],
-                'Event Match Screen',
+                "Event Match Screen",
                 running,
                 stop,
                 max_attempts=10,
             ):
                 if not self.image_processor.check_and_click_until_found(
                     self.template_images["RANDOM_MATCH_SCREEN"],
-                    'Random Match Screen',
+                    "Random Match Screen",
                     running,
                     stop,
                     max_attempts=10,
@@ -70,7 +71,7 @@ class BattleActions:
         else:
             if not self.image_processor.check_and_click_until_found(
                 self.template_images["RANDOM_MATCH_SCREEN"],
-                'Random Match Screen',
+                "Random Match Screen",
                 running,
                 stop,
                 max_attempts=10,
@@ -78,7 +79,7 @@ class BattleActions:
                 return False
         if not self.image_processor.check_and_click_until_found(
             self.template_images["BATTLE_BUTTON"],
-            'Battle Button',
+            "Battle Button",
             running,
             stop,
             max_attempts=10,
@@ -86,7 +87,7 @@ class BattleActions:
             return False
 
     def check_rival_concede(self, screenshot, running, stop):
-        self.log_callback(f"Checking if the rival conceded...")
+        self.log_callback("Checking if the rival conceded...")
         if self.image_processor.check(
             screenshot, self.template_images["TAP_TO_PROCEED_BUTTON"], "Rival conceded"
         ):
@@ -103,11 +104,11 @@ class BattleActions:
                     break
             time.sleep(2)
             self.image_processor.check_and_click_until_found(
-                self.template_images["CROSS_BUTTON"], 'Cross button', running, stop
+                self.template_images["CROSS_BUTTON"], "Cross button", running, stop
             )
             time.sleep(4)
         else:
-            self.log_callback(f"Rival hasn't conceded")
+            self.log_callback("Rival hasn't conceded")
 
     def get_card(self, x, y, duration=1.0):
         x_zoom_card_region, y_zoom_card_region, w, h = self.zoom_card_region
@@ -130,7 +131,7 @@ class BattleActions:
         return identified_card
 
     def check_number_of_cards(self, card_x, card_y):
-        self.log_callback(f"Checking the number of cards...")
+        self.log_callback("Checking the number of cards...")
         long_press_position(card_x, card_y, 1.5)
 
         number_image = self.image_processor.capture_region(self.number_of_cards_region)

--- a/bot.py
+++ b/bot.py
@@ -1,23 +1,25 @@
-import time
-import cv2
-import threading
-import numpy as np
-from adb_utils import (
-    connect_to_emulator,
-    click_position,
-    take_screenshot,
-    drag_position,
-)
-from loaders import load_template_images, load_all_cards
-import uuid
 import os
-from deck import deck_info, save_deck
-from card_data_manager import CardDataManager
-from image_utils import ImageProcessor
-from battle_actions import BattleActions
-from constants import default_pokemon_stats, bench_positions, card_offset_mapping
 import subprocess
+import threading
+import time
+import uuid
+
+import cv2
+import numpy as np
 import requests
+
+from adb_utils import (
+    click_position,
+    connect_to_emulator,
+    drag_position,
+    take_screenshot,
+)
+from battle_actions import BattleActions
+from card_data_manager import CardDataManager
+from constants import bench_positions, card_offset_mapping, default_pokemon_stats
+from deck import deck_info, save_deck
+from image_utils import ImageProcessor
+from loaders import load_all_cards, load_template_images
 
 
 class PokemonBot:
@@ -125,7 +127,7 @@ class PokemonBot:
             ### BATTLE START
             self.image_processor.check_and_click_until_found(
                 self.template_images["TIME_LIMIT_INDICATOR"],
-                "Time limit indicator",  # noqa
+                "Time limit indicator",
                 self.running,
                 self.stop,
             )
@@ -586,14 +588,14 @@ class PokemonBot:
         ):
             return False
 
-        self.log_callback(f"Click bench slots...")
+        self.log_callback("Click bench slots...")
         for bench_position in bench_positions:
             click_position(bench_position[0], bench_position[1])
 
     def check_field(self):
         if not self.running:
             return False
-        self.log_callback(f"Checking the field...")
+        self.log_callback("Checking the field...")
 
         self.check_active_pokemon()
         self.reset_view()

--- a/card_data_manager.py
+++ b/card_data_manager.py
@@ -1,7 +1,8 @@
 # src/card_data_manager.py
-import requests
 import json
 import os
+
+import requests
 
 
 class CardDataManager:
@@ -14,7 +15,7 @@ class CardDataManager:
 
     def load_card_data(self):
         if os.path.exists(self.CACHE_FILE):
-            with open(self.CACHE_FILE, "r") as f:
+            with open(self.CACHE_FILE) as f:
                 self.card_data = json.load(f)
                 print(f"Number of cards loaded from cache: {len(self.card_data)}")
         else:

--- a/concede.py
+++ b/concede.py
@@ -1,10 +1,14 @@
-import time
-import cv2
-import threading
-import numpy as np
-from adb_utils import connect_to_emulator, click_position, take_screenshot, find_subimage, long_press_position
-from loaders import load_template_images
 import subprocess
+import threading
+import time
+
+from adb_utils import (
+    click_position,
+    connect_to_emulator,
+    find_subimage,
+    take_screenshot,
+)
+from loaders import load_template_images
 
 
 class PokemonConcedeBot:
@@ -13,13 +17,12 @@ class PokemonConcedeBot:
         self.log_callback = log_callback
         self.running = False
         self.template_images = load_template_images("images")
-        
+
         self.turn_check_region = (50, 1560, 200, 20)
         self.card_start_x = 500
         self.card_y = 1500
         self.card_offset_x = 60
         self.zoom_card_region = (200, 360, 570, 400)
-
 
     def start(self):
         if not self.app_state.program_path:
@@ -31,7 +34,6 @@ class PokemonConcedeBot:
     def stop(self):
         self.running = False
 
-
     def connect_and_run(self):
         if self.app_state.emulator_name:
             connect_to_emulator(self.app_state.emulator_name)
@@ -40,7 +42,6 @@ class PokemonConcedeBot:
             connect_to_emulator(emulator_name)
         self.log_callback("Connected to emulator")
         self.run_script()
-
 
     def get_emulator_name(self):
         try:
@@ -63,14 +64,20 @@ class PokemonConcedeBot:
                 return None
         except Exception as e:
             print(f"Error getting emulator name: {e}")
-            return None    
+            return None
 
     def run_script(self):
         while self.running:
             screenshot = take_screenshot()
 
-            if not self.check_and_click(screenshot, self.template_images["BATTLE_ALREADY_SCREEN"], "Battle already screen"):
-                self.check_and_click(screenshot, self.template_images["BATTLE_SCREEN"], "Battle screen")
+            if not self.check_and_click(
+                screenshot,
+                self.template_images["BATTLE_ALREADY_SCREEN"],
+                "Battle already screen",
+            ):
+                self.check_and_click(
+                    screenshot, self.template_images["BATTLE_SCREEN"], "Battle screen"
+                )
             time.sleep(1)
             self.perform_search_battle_actions()
             self.perform_concede_actions()
@@ -81,7 +88,9 @@ class PokemonConcedeBot:
             "RANDOM_MATCH_SCREEN",
             "BATTLE_BUTTON",
         ]:
-            if not self.check_and_click_until_found(self.template_images[key], f"{key.replace('_', ' ').title()}"):
+            if not self.check_and_click_until_found(
+                self.template_images[key], f"{key.replace('_', ' ').title()}"
+            ):
                 break
 
     def perform_concede_actions(self):
@@ -93,19 +102,29 @@ class PokemonConcedeBot:
             "NEXT_BUTTON",
             "THANKS_BUTTON",
         ]:
-            if not self.check_and_click_until_found(self.template_images[key], f"{key.replace('_', ' ').title()}"):
+            if not self.check_and_click_until_found(
+                self.template_images[key], f"{key.replace('_', ' ').title()}"
+            ):
                 break
         time.sleep(2)
-        self.check_and_click_until_found(self.template_images["CROSS_BUTTON"], "Cross button")
+        self.check_and_click_until_found(
+            self.template_images["CROSS_BUTTON"], "Cross button"
+        )
         time.sleep(4)
 
     def check(self, screenshot, template_image, log_message, similarity_threshold=0.8):
         _, similarity = find_subimage(screenshot, template_image)
-        log_message = f"{log_message} found - {similarity:.2f}" if similarity > similarity_threshold else f"{log_message} NOT found - {similarity:.2f}"
+        log_message = (
+            f"{log_message} found - {similarity:.2f}"
+            if similarity > similarity_threshold
+            else f"{log_message} NOT found - {similarity:.2f}"
+        )
         self.log_callback(log_message)
         return similarity > similarity_threshold
 
-    def check_and_click(self, screenshot, template_image, log_message, similarity_threshold=0.8):
+    def check_and_click(
+        self, screenshot, template_image, log_message, similarity_threshold=0.8
+    ):
         position, similarity = find_subimage(screenshot, template_image)
         if similarity > similarity_threshold:
             self.log_and_click(position, f"{log_message} found - {similarity:.2f}")
@@ -114,7 +133,9 @@ class PokemonConcedeBot:
             self.log_callback(f"{log_message} NOT found - {similarity:.2f}")
             return False
 
-    def check_and_click_until_found(self, template_image, log_message, similarity_threshold=0.8, timeout=30):
+    def check_and_click_until_found(
+        self, template_image, log_message, similarity_threshold=0.8, timeout=30
+    ):
         start_time = time.time()
         attempts = 0
         max_attempts = 10
@@ -129,7 +150,9 @@ class PokemonConcedeBot:
                 return True
             elif time.time() - start_time > timeout:
                 attempts += 1
-                self.log_callback(f"{log_message} not found within timeout. Attempt {attempts}/{max_attempts}.")
+                self.log_callback(
+                    f"{log_message} not found within timeout. Attempt {attempts}/{max_attempts}."
+                )
                 if attempts >= max_attempts:
                     self.log_callback("Max attempts reached. Stopping the bot.")
                     self.stop()

--- a/config_manager.py
+++ b/config_manager.py
@@ -1,5 +1,6 @@
 import os
 
+
 class ConfigManager:
     def __init__(self, filename="configs.txt"):
         self.filename = filename
@@ -7,7 +8,7 @@ class ConfigManager:
     def load(self):
         config = {}
         if os.path.exists(self.filename):
-            with open(self.filename, "r") as f:
+            with open(self.filename) as f:
                 for line in f:
                     if " = " in line:
                         key, val = line.strip().split(" = ")

--- a/constants.py
+++ b/constants.py
@@ -1,19 +1,11 @@
 default_pokemon_stats = {
-    "level": 0, 
-    "energies": 0, 
-    "evolves_from": None, 
-    "can_evolve": False, 
-    "item_card": False
+    "level": 0,
+    "energies": 0,
+    "evolves_from": None,
+    "can_evolve": False,
+    "item_card": False,
 }
 
-bench_positions = [(200, 1250),(500, 1250),(700, 1250)]
+bench_positions = [(200, 1250), (500, 1250), (700, 1250)]
 
-card_offset_mapping = {
-    2: 90,
-    3: 80,
-    4: 70,
-    5: 60,
-    6: 50,
-    7: 45,
-    8: 40
-}
+card_offset_mapping = {2: 90, 3: 80, 4: 70, 5: 60, 6: 50, 7: 45, 8: 40}

--- a/deck.py
+++ b/deck.py
@@ -7,7 +7,7 @@ DECK_FILE = "deck.json"
 
 def load_deck():
     if os.path.exists(DECK_FILE):
-        with open(DECK_FILE, "r") as f:
+        with open(DECK_FILE) as f:
             return json.load(f)
     else:
         return {}

--- a/image_utils.py
+++ b/image_utils.py
@@ -1,8 +1,11 @@
-import cv2
-import numpy as np
-import easyocr
-from adb_utils import take_screenshot, find_subimage, click_position
 import time
+
+import cv2
+import easyocr
+import numpy as np
+
+from adb_utils import click_position, find_subimage, take_screenshot
+
 
 class ImageProcessor:
     def __init__(self, log_callback):
@@ -17,32 +20,44 @@ class ImageProcessor:
 
     def extract_number_from_image(self, image):
         grayscale_image = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
-        reader = easyocr.Reader(['en'])
+        reader = easyocr.Reader(["en"])
 
         result = reader.readtext(grayscale_image, detail=0)
 
         numbers = [text for text in result if text.isdigit()]
-        
+
         if numbers:
             return numbers[0]
         else:
             return None
-        
+
     def capture_region(self, region):
         x, y, w, h = region
         screenshot = take_screenshot()
-        return screenshot[y:y+h, x:x+w]
-    
+        return screenshot[y : y + h, x : x + w]
+
     def check(self, screenshot, template_image, log_message, similarity_threshold=0.8):
         _, similarity = find_subimage(screenshot, template_image)
         if log_message:
-            log_message = f"{log_message} found - {similarity:.2f}" if similarity > similarity_threshold else f"{log_message} NOT found - {similarity:.2f}"
+            log_message = (
+                f"{log_message} found - {similarity:.2f}"
+                if similarity > similarity_threshold
+                else f"{log_message} NOT found - {similarity:.2f}"
+            )
             self.log_callback(log_message)
         return similarity > similarity_threshold
-    
-    def check_and_click_until_found(self, template_image, log_message, running, stop, similarity_threshold=0.8, max_attempts=50):
+
+    def check_and_click_until_found(
+        self,
+        template_image,
+        log_message,
+        running,
+        stop,
+        similarity_threshold=0.8,
+        max_attempts=50,
+    ):
         attempts = 0
-        
+
         while running:
             screenshot = take_screenshot()
             position, similarity = find_subimage(screenshot, template_image)
@@ -53,13 +68,17 @@ class ImageProcessor:
                 return True
             elif similarity < similarity_threshold:
                 attempts += 1
-                self.log_callback(f"{log_message} not found. Attempt {attempts}/{max_attempts}.")
+                self.log_callback(
+                    f"{log_message} not found. Attempt {attempts}/{max_attempts}."
+                )
                 if attempts >= max_attempts:
                     self.log_callback("Max attempts reached. Stopping the bot.")
                     return False
                 time.sleep(0.5)
 
-    def check_and_click(self, screenshot, template_image, log_message, similarity_threshold=0.8):
+    def check_and_click(
+        self, screenshot, template_image, log_message, similarity_threshold=0.8
+    ):
         position, similarity = find_subimage(screenshot, template_image)
         if similarity > similarity_threshold:
             if log_message:
@@ -72,4 +91,4 @@ class ImageProcessor:
 
     def log_and_click(self, position, message):
         self.log_callback(message)
-        click_position(position[0], position[1])            
+        click_position(position[0], position[1])

--- a/loaders.py
+++ b/loaders.py
@@ -1,5 +1,7 @@
-import cv2
 import os
+
+import cv2
+
 
 def load_template_images(template_folder):
     template_images = {}
@@ -9,7 +11,7 @@ def load_template_images(template_folder):
         return template_images
 
     for filename in os.listdir(template_folder):
-        if filename.endswith(('.PNG')):
+        if filename.endswith(".PNG"):
             file_path = os.path.join(template_folder, filename)
             image = cv2.imread(file_path)
             if image is not None:
@@ -20,15 +22,17 @@ def load_template_images(template_folder):
                 print(f"Failed to load template: {file_path}")
 
     return template_images
+
+
 def load_all_cards(image_folder):
     card_images = {}
-    
+
     if not os.path.exists(image_folder):
         print(f"Directory {image_folder} does not exist.")
         return card_images
 
     for filename in os.listdir(image_folder):
-        if filename.endswith(('.png', '.jpg', '.jpeg')):
+        if filename.endswith((".png", ".jpg", ".jpeg")):
             file_path = os.path.join(image_folder, filename)
             image = cv2.imread(file_path)
             if image is not None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ numpy==2.1.2
 opencv_python==4.9.0.80
 opencv_python_headless==4.10.0.84
 tk
+ruff

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,38 @@
+# Exclude files/directories
+exclude = [
+    ".git",
+    ".venv",
+    "__pycache__",
+    "build",
+    "dist"
+]
+
+# Same as Black.
+line-length = 88
+indent-width = 4
+
+# Assume Python 3.8
+target-version = "py38"
+
+[lint]
+# Enable all rules by default
+select = ["E", "F", "I", "N", "W", "B", "C4", "UP", "RUF"]
+
+# Never enforce `E501` (line length violations) - handled by formatter
+ignore = ["E501"]
+
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[format]
+# Use double quotes for strings.
+quote-style = "double"
+
+# Indent with spaces, rather than tabs.
+indent-style = "space"
+
+# Respect magic trailing commas.
+skip-magic-trailing-comma = false
+
+# Automatically detect the appropriate line ending.
+line-ending = "auto" 

--- a/ui.py
+++ b/ui.py
@@ -1,13 +1,15 @@
 import tkinter as tk
 from tkinter import filedialog
-from config_manager import ConfigManager
+
+import cv2
+import numpy as np
+import requests
+from PIL import Image, ImageTk
+
+from adb_utils import take_screenshot
 from bot import PokemonBot
 from concede import PokemonConcedeBot
-from adb_utils import connect_to_emulator, take_screenshot
-from PIL import Image, ImageTk
-import requests
-import numpy as np
-import cv2
+from config_manager import ConfigManager
 
 
 class BotUI:


### PR DESCRIPTION
Introduced Ruff as the primary linting tool in the workspace settings, while disabling other linters. This change enhances code quality by enforcing consistent formatting and linting rules. The codebase has been cleaned by reordering imports, establishing a more organized structure, and making the code more readable.

This update prepares the project for better maintainability and aligns it with modern Python practices. Cleaner imports and consistent formatting contribute to a more efficient development experience.

No functional changes to the overall behavior of the code were made as part of this commit.