### PR TITLE
ADD requests requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ numpy==2.1.2
 opencv_python==4.9.0.80
 opencv_python_headless==4.10.0.84
 tk
+requests


### PR DESCRIPTION
The module requests is now used to retrieve the card information from the API, but it needs to be on the requirements.txt in order to be installed.