### PR TITLE
Change window name of the bot

### DIFF
--- a/views/main_ui/bot_ui.py
+++ b/views/main_ui/bot_ui.py
@@ -64,6 +64,7 @@ class BotUI:
         # Update window size
         self.root.geometry(f"{WINDOW_CONFIG['width']}x{WINDOW_CONFIG['height']}")
         self.root.configure(bg=UI_COLORS["bg"])
+        self.root.title("Pokemon Pocket Bot")
 
         # Setup menu
         MenuBuilder(self).build()


### PR DESCRIPTION
The window name of the bot was "tk", now it has been changed to "Pokemon Pocket bot"

Before:
![image](https://github.com/user-attachments/assets/b006c772-327f-4ccb-adc9-aef61dd21271)

After:
![image](https://github.com/user-attachments/assets/0daddadf-6e4d-4932-9d75-a2f6f691f4f5)
